### PR TITLE
CSM-7167: GCP Terraform Project Integration: We need to give array of roles as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ Access is setup with Workload Identity Pool (WIP) where AWS is the identity prov
 This avoids sharing sensitive keys.
 
 This terraform module will create following resources:-
- * Service account
- * Workload Identity Pool
- * Identity Provider AWS
- * It will attach below policies to service account
-     * roles/iam.securityReviewer
-     * roles/bigquery.resourceViewer
-     * roles/pubsub.subscriber
-     * roles/viewer
+
+* Service account
+* Workload Identity Pool
+* Identity Provider AWS
+* It will attach below policies to service account
+  * roles/iam.securityReviewer
+  * roles/bigquery.resourceViewer
+  * roles/pubsub.subscriber
+  * roles/viewer
 
 # Requirements
 
@@ -23,13 +24,13 @@ The following dependencies must be available:
 
 * The principal executing the TF should have following permissions
 
-   * Service Account Admin
-   * IAM Workload Identity Pool Admin
-   * Project IAM Admin
+  * Service Account Admin
+  * IAM Workload Identity Pool Admin
+  * Project IAM Admin
 
 ## 2. Install terraform
 
-## 3. Install Google Cloud SDK 
+## 3. Install Google Cloud SDK
 
 ## 4. Authenticate
 
@@ -42,7 +43,8 @@ Login with ADC
 
 ## 5. Use terraform module steps
 
-  * Create a <filename>.tf file, paste below codes and modify as needed.
+* Create a <filename>.tf file, paste below codes and modify as needed.
+
 ```
 module "create-gcp-cred" {
   source                    = "github.com/uptycslabs/terraform-google-iam-config"
@@ -59,7 +61,7 @@ module "create-gcp-cred" {
   # Copy Uptycs's AWS Account ID and Role from Uptycs' UI.
   # Uptycs' UI: "Cloud"->"GCP"->"Integrations"->"PROJECT INTEGRATION"
   host_aws_account_id     = "<AWS account id>"
-  host_aws_instance_role  = "<AWS role>"
+  host_aws_instance_role  = ["Role_Allinone","Role_PNode", "Role_Cloudquery"]
 
   # Modify if required
   gcp_workload_identity = "wip-uptycs"
@@ -77,41 +79,41 @@ output "command-to-generate-gcp-cred-config" {
 
 ## Inputs
 
-| Name                      | Description                                                                                                        | Type          | Required | Default          |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------- | -------- | ---------------- |
-| gcp_region                | The GCP project region where planning to create resources.                                                         | `string`      |          |`us-east-1`      |
-| gcp_project_id            | The GCP project id where you want to create resources.                                                             | `string`      | Yes      |                 |
-| gcp_project_number        | The GCP project number of above passed project id.                                                                 | `number`      | Yes      |              |
-| is_service_account_exists | Set this to false                                                                                                  | `bool`        |          | `false`          |
-| service_account_name      | The GCP service account name                                                                                       | `string`      |          | `"sa-for-uptycs"` |
-| host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI                                              | `number`      | Yes      |              |
-| host_aws_instance_role    | Uptycs's AWS Role name. Copy from Uptycs's GCP Integration Screen UI                                               | `string`      | Yes      |              |
-| gcp_workload_identity     | Workload Identity Pool to allow Uptycs integration via AWS federation                                              | `string`      |          | `"wip-uptycs"`             |
-| gcp_wip_provider_id       | Workload Identity Pool provider id allow to add cloud provider                                                     | `string`      |          | `"uptycs-aws-idp"`             |
 
+| Name                      | Description                                                           | Type           | Required | Default            |
+| --------------------------- | ----------------------------------------------------------------------- | ---------------- | ---------- | -------------------- |
+| gcp_region                | The GCP project region where planning to create resources.            | `string`       |          | `us-east-1`        |
+| gcp_project_id            | The GCP project id where you want to create resources.                | `string`       | Yes      |                    |
+| gcp_project_number        | The GCP project number of above passed project id.                    | `string`       | Yes      |                    |
+| is_service_account_exists | Set this to false                                                     | `bool`         |          | `false`            |
+| service_account_name      | The GCP service account name                                          | `string`       |          | `"sa-for-uptycs"`  |
+| host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI | `string`       | Yes      |                    |
+| host_aws_instance_role    | AWS role names of Uptycs - for identity binding | `list(string)` | Yes      |                    |
+| gcp_workload_identity     | Workload Identity Pool to allow Uptycs integration via AWS federation | `string`       |          | `"wip-uptycs"`     |
+| gcp_wip_provider_id       | Workload Identity Pool provider id allow to add cloud provider        | `string`       |          | `"uptycs-aws-idp"` |
 
 ## Outputs
 
-| Name                    | Description                                  |
-| ----------------------- | -------------------------------------------- |
-| service-account-email   | The deployed Service Account's email-id |
-| command-to-generate-gcp-cred-config  | For creating again same cred config json data ,please use command return by "command-to-generate-gcp-cred-config" |
 
+| Name                                | Description                                                                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| service-account-email               | The deployed Service Account's email-id                                                                           |
+| command-to-generate-gcp-cred-config | For creating again same cred config json data ,please use command return by "command-to-generate-gcp-cred-config" |
 
 ## Notes
 
 1. service account details
-     - Set `is_service_account_exists = true`, if service account already exists. Specify existing service account name using `service_account_name`.
-     - Set `is_service_account_exists = false` if service account does not exist. Provide a new name via `service_account_name`.
 
+   - Set `is_service_account_exists = true`, if service account already exists. Specify existing service account name using `service_account_name`.
+   - Set `is_service_account_exists = false` if service account does not exist. Provide a new name via `service_account_name`.
 2. Workload Identity Pool is soft-deleted and permanently deleted after approximately 30 days.
-     - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`. ID cannot be re-used until the WIP is permanently deleted.
-     - After `terraform destroy`, same WIP can't be created again. Modify `gcp_workload_identity` value if required.
 
+   - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`. ID cannot be re-used until the WIP is permanently deleted.
+   - After `terraform destroy`, same WIP can't be created again. Modify `gcp_workload_identity` value if required.
 3. `credentials.json` is created once. Use the command returned by `command-to-generate-gcp-cred-config` output to recreate.
 
-
 ## 6.Execute Terraform script to get credentials JSON
+
 ```
 $ terraform init
 $ terraform plan

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module "create-gcp-cred" {
   # Modify Project details reequired
   gcp_project_id            = "<GCP-project-id>"
 
-  is_service_account_exists = false
+  service_account_exists = false
   service_account_name      = "sa-for-uptycs"
 
   # AWS account details
@@ -80,7 +80,7 @@ output "command-to-generate-gcp-cred-config" {
 | Name                      | Description                                                                    | Type           | Required | Default                 |
 | --------------------------- | -------------------------------------------------------------------------------- | ---------------- | ---------- | ------------------------- |
 | gcp_project_id            | The GCP project id where you want to create resources.                         | `string`       | Yes      |                         |
-| is_service_account_exists | Set this to true if you want to use existing service account.Else set to false | `bool`         |          | `false`                 |
+| service_account_exists | Set this to true if you want to use existing service account.Else set to false | `bool`         |          | `false`                 |
 | service_account_name      | The GCP service account name                                                   | `string`       |          | `"sa-for-uptycs"`       |
 | host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI          | `string`       | Yes      |                         |
 | host_aws_instance_role    | AWS role names of Uptycs - for identity binding                                | `list(string)` | Yes      |                         |
@@ -98,8 +98,8 @@ output "command-to-generate-gcp-cred-config" {
 
 1. service account details
 
-   - Set `is_service_account_exists = true`, if service account already exists. Specify existing service account name using `service_account_name`.
-   - Set `is_service_account_exists = false` if service account does not exist. Provide a new name via `service_account_name`.
+   - Set `service_account_exists = true`, if service account already exists. Specify existing service account name using `service_account_name`.
+   - Set `service_account_exists = false` if service account does not exist. Provide a new name via `service_account_name`.
 2. Workload Identity Pool is soft-deleted and permanently deleted after approximately 30 days.
 
    - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`.  `integration_name` cannot be re-used until the WIP is permanently deleted.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ output "command-to-generate-gcp-cred-config" {
 ## 6.Execute Terraform script to get credentials JSON
 
 ```
-$ terraform init
+$ terraform init -upgrade
 $ terraform plan
 $ terraform apply # NOTE: Once terraform is successfully applied, it will create "credentials.json" file.
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ output "command-to-generate-gcp-cred-config" {
 | service_account_exists | Set this to true if you want to use existing service account.Else set to false | `bool`         |          | `false`                 |
 | service_account_name      | The GCP service account name                                                   | `string`       |          | `"sa-for-uptycs"`       |
 | host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI          | `string`       | Yes      |                         |
-| host_aws_instance_role    | AWS role names of Uptycs - for identity binding                                | `list(string)` | Yes      |                         |
+| host_aws_instance_roles    | AWS role names of Uptycs - for identity binding                                | `list(string)` | Yes      |                         |
 | integration_name          | Unique phrase used to name the resources                                       | `string`       |          | `"uptycs-int-20220101"` |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ module "create-gcp-cred" {
   source                    = "github.com/uptycslabs/terraform-google-iam-config"
 
   # Modify Project details reequired
-  gcp_region                = "us-east1"
   gcp_project_id            = "<GCP-project-id>"
-  gcp_project_number        = "<GCP-project-number>"
 
   is_service_account_exists = false
   service_account_name      = "sa-for-uptycs"
@@ -61,11 +59,10 @@ module "create-gcp-cred" {
   # Copy Uptycs's AWS Account ID and Role from Uptycs' UI.
   # Uptycs' UI: "Cloud"->"GCP"->"Integrations"->"PROJECT INTEGRATION"
   host_aws_account_id     = "<AWS account id>"
-  host_aws_instance_role  = ["Role_Allinone","Role_PNode", "Role_Cloudquery"]
+  host_aws_instance_roles  = ["Role_Allinone","Role_PNode", "Role_Cloudquery"]
 
   # Modify if required
-  gcp_workload_identity = "wip-uptycs"
-  gcp_wip_provider_id   = "uptycs-aws-idp"
+  integration_name = "uptycs-int-20220101"
 }
 
 output "service-account-email" {
@@ -80,17 +77,14 @@ output "command-to-generate-gcp-cred-config" {
 ## Inputs
 
 
-| Name                      | Description                                                           | Type           | Required | Default            |
-| --------------------------- | ----------------------------------------------------------------------- | ---------------- | ---------- | -------------------- |
-| gcp_region                | The GCP project region where planning to create resources.            | `string`       |          | `us-east-1`        |
-| gcp_project_id            | The GCP project id where you want to create resources.                | `string`       | Yes      |                    |
-| gcp_project_number        | The GCP project number of above passed project id.                    | `string`       | Yes      |                    |
-| is_service_account_exists | Set this to false                                                     | `bool`         |          | `false`            |
-| service_account_name      | The GCP service account name                                          | `string`       |          | `"sa-for-uptycs"`  |
-| host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI | `string`       | Yes      |                    |
-| host_aws_instance_role    | AWS role names of Uptycs - for identity binding | `list(string)` | Yes      |                    |
-| gcp_workload_identity     | Workload Identity Pool to allow Uptycs integration via AWS federation | `string`       |          | `"wip-uptycs"`     |
-| gcp_wip_provider_id       | Workload Identity Pool provider id allow to add cloud provider        | `string`       |          | `"uptycs-aws-idp"` |
+| Name                      | Description                                                                    | Type           | Required | Default                 |
+| --------------------------- | -------------------------------------------------------------------------------- | ---------------- | ---------- | ------------------------- |
+| gcp_project_id            | The GCP project id where you want to create resources.                         | `string`       | Yes      |                         |
+| is_service_account_exists | Set this to true if you want to use existing service account.Else set to false | `bool`         |          | `false`                 |
+| service_account_name      | The GCP service account name                                                   | `string`       |          | `"sa-for-uptycs"`       |
+| host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI          | `string`       | Yes      |                         |
+| host_aws_instance_role    | AWS role names of Uptycs - for identity binding                                | `list(string)` | Yes      |                         |
+| integration_name          | Unique phrase used to name the resources                                       | `string`       |          | `"uptycs-int-20220101"` |
 
 ## Outputs
 
@@ -108,8 +102,8 @@ output "command-to-generate-gcp-cred-config" {
    - Set `is_service_account_exists = false` if service account does not exist. Provide a new name via `service_account_name`.
 2. Workload Identity Pool is soft-deleted and permanently deleted after approximately 30 days.
 
-   - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`. ID cannot be re-used until the WIP is permanently deleted.
-   - After `terraform destroy`, same WIP can't be created again. Modify `gcp_workload_identity` value if required.
+   - Soft-deleted provider can be restored using `UndeleteWorkloadIdentityPoolProvider`.  `integration_name` cannot be re-used until the WIP is permanently deleted.
+   - After `terraform destroy`, same WIP can't be created again. Modify `integration_name` value if required.
 3. `credentials.json` is created once. Use the command returned by `command-to-generate-gcp-cred-config` output to recreate.
 
 ## 6.Execute Terraform script to get credentials JSON

--- a/examples/create-gcp-cred.tf
+++ b/examples/create-gcp-cred.tf
@@ -1,18 +1,15 @@
 module "create-gcp-cred" {
   source                    = "github.com/uptycslabs/terraform-google-iam-config"
-  gcp_region                = "us-east1"
   gcp_project_id            = "test-project"
-  gcp_project_number        = "11111111111"
   is_service_account_exists = false
   service_account_name      = "sa-for-testing"
 
   # AWS account details
   host_aws_account_id     = "1234567890"
-  host_aws_instance_role  = "Test_Role_Allinone"
+  host_aws_instance_roles  = ["Role_Allinone","Role_PNode", "Role_Cloudquery"]
 
   # Modify if required
-  gcp_workload_identity = "wip-testing12"
-  gcp_wip_provider_id   = "aws-id-provider-test"
+  integration_name = "uptycs-int-20220101"
 }
 
 output "service-account-email" {

--- a/examples/create-gcp-cred.tf
+++ b/examples/create-gcp-cred.tf
@@ -1,7 +1,7 @@
 module "create-gcp-cred" {
   source                    = "github.com/uptycslabs/terraform-google-iam-config"
   gcp_project_id            = "test-project"
-  is_service_account_exists = false
+  service_account_exists    = false
   service_account_name      = "sa-for-testing"
 
   # AWS account details

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "google_service_account" "myaccount" {
-  count      = var.is_service_account_exists ? 1 : 0
+  count      = var.service_account_exists ? 1 : 0
   account_id = var.service_account_name
   project    = var.gcp_project_id
 }
@@ -28,7 +28,7 @@ resource "google_iam_workload_identity_pool_provider" "add_provider" {
 }
 
 resource "google_service_account" "sa_for_cloudquery" {
-  count        = var.is_service_account_exists ? 0 : 1
+  count        = var.service_account_exists ? 0 : 1
   project      = var.gcp_project_id
   account_id   = var.service_account_name
   display_name = var.service_account_name
@@ -38,36 +38,36 @@ resource "google_service_account" "sa_for_cloudquery" {
 resource "google_project_iam_member" "bind_security_viewer" {
   role    = "roles/iam.securityReviewer"
   project = var.gcp_project_id
-  member  = var.is_service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
 }
 
 resource "google_project_iam_member" "bind_resourceViewer" {
   role    = "roles/bigquery.resourceViewer"
   project = var.gcp_project_id
-  member  = var.is_service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
 }
 
 resource "google_project_iam_member" "bind_pubsub_subscriber" {
   role    = "roles/pubsub.subscriber"
   project = var.gcp_project_id
-  member  = var.is_service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
 }
 
 resource "google_project_iam_member" "bind_viewer" {
   role    = "roles/viewer"
   project = var.gcp_project_id
-  member  = var.is_service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
+  member  = var.service_account_exists == false ? "serviceAccount:${google_service_account.sa_for_cloudquery[0].email}" : "serviceAccount:${data.google_service_account.myaccount[0].email}"
 }
 
 resource "google_service_account_iam_binding" "workload_identity_binding" {
-  service_account_id = var.is_service_account_exists == false ? "${google_service_account.sa_for_cloudquery[0].name}" : "${data.google_service_account.myaccount[0].name}"
+  service_account_id = var.service_account_exists == false ? "${google_service_account.sa_for_cloudquery[0].name}" : "${data.google_service_account.myaccount[0].name}"
   role               = "roles/iam.workloadIdentityUser"
   members = [for each in var.host_aws_instance_roles : format("principalSet://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/attribute.aws_role/arn:aws:sts::%s:assumed-role/%s", data.google_project.my_host_project.number,google_iam_workload_identity_pool.create_wip.workload_identity_pool_id,var.host_aws_account_id, each)]
 }
 
 resource "null_resource" "cred_config_json" {
   provisioner "local-exec" {
-    command     = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.is_service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
+    command     = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
     interpreter = ["/bin/sh", "-c"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -58,9 +58,7 @@ resource "google_project_iam_member" "bind_viewer" {
 resource "google_service_account_iam_binding" "workload_identity_binding" {
   service_account_id = var.is_service_account_exists == false ? "${google_service_account.sa_for_cloudquery[0].name}" : "${data.google_service_account.myaccount[0].name}"
   role               = "roles/iam.workloadIdentityUser"
-  members = [
-    "principalSet://iam.googleapis.com/projects/${var.gcp_project_number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/attribute.aws_role/arn:aws:sts::${var.host_aws_account_id}:assumed-role/${var.host_aws_instance_role}"
-  ]
+  members = [for each in var.host_aws_instance_role : format("principalSet://iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/attribute.aws_role/arn:aws:sts::%s:assumed-role/%s", var.gcp_project_number,google_iam_workload_identity_pool.create_wip.workload_identity_pool_id,var.host_aws_account_id, each)]
 }
 
 resource "null_resource" "cred_config_json" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,8 @@
 output "service-account-email" {
   description = "The deployed Service Account's email-id"
-  value       = var.is_service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email
+  value       = var.service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email
 }
 
 output "command-to-generate-gcp-cred-config" {
-  value = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.is_service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
+  value = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,5 +4,5 @@ output "service-account-email" {
 }
 
 output "command-to-generate-gcp-cred-config" {
-  value = "gcloud iam workload-identity-pools create-cred-config projects/${var.gcp_project_number}/locations/global/workloadIdentityPools/${var.gcp_workload_identity}/providers/${var.gcp_wip_provider_id} --service-account=${var.is_service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
+  value = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.is_service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,8 @@
-variable "gcp_region" {
-  type        = string
-  description = "The GCP project region where planning to create resources "
-  default     = "us-east1"
-}
-
 variable "gcp_project_id" {
   type        = string
   description = "The GCP project ID where planning to create resources"
-  default     = "test-project"
 }
 
-variable "gcp_project_number" {
-  type        = string
-  description = "The GCP project number"
-}
 
 variable "is_service_account_exists" {
   type        = bool
@@ -27,25 +16,19 @@ variable "service_account_name" {
   default     = "sa-for-test"
 }
 
-variable "gcp_workload_identity" {
+variable "integration_name" {
   type        = string
-  description = "Workload Identity Pool to allow Uptycs integration via AWS federation."
-  default     = "wip-test"
+  description = "Unique phrase used to name the resources"
+  default     = "uptycs-int-20220101"
 }
 
-variable "gcp_wip_provider_id" {
-  type        = string
-  description = "Workload Identity Pool provider ID allow to add cloud provider."
-  default     = "aws-id-provider-test"
-}
 
 variable "host_aws_account_id" {
   type        = string
-  description = "The deployer host AWS account ID."
-  default     = "11111111111111"
+  description = "AWS account ID of Uptycs - for federated identity"
 }
 
-variable "host_aws_instance_role" {
+variable "host_aws_instance_roles" {
   type        = list 
   description = "AWS role names of Uptycs - for identity binding"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "gcp_project_id" {
 }
 
 variable "gcp_project_number" {
-  type        = number
+  type        = string
   description = "The GCP project number"
 }
 
@@ -46,7 +46,6 @@ variable "host_aws_account_id" {
 }
 
 variable "host_aws_instance_role" {
-  type        = string
-  description = "The attached deployer host AWS role name."
-  default     = "Test_Role_Allinone"
+  type        = list 
+  description = "AWS role names of Uptycs - for identity binding"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "gcp_project_id" {
 }
 
 
-variable "is_service_account_exists" {
+variable "service_account_exists" {
   type        = bool
   description = "Set true if service account is already exists . "
   default     = false


### PR DESCRIPTION
- Here we are giving `host_aws_instance_role` as a string with one role.
- It is changed to accept array of uptycs aws roles

### Test cases:

- [x] Modified the `host_aws_instance_role` with `["Role_Allinone","Role_PNode", "Role_Cloudquery"] ` and run terraform. Checked Iam principals of service account after terraform applied successfully,there is principals with given aws_account and with the roles `Role_Allinone`,`Role_PNode`, `Role_Cloudquery`
- [x] Checked all permissions attached to service account properly on not
- [x] Tested by integrating the project with generated credentials
- [x] Tested command we get from output whether it is generating credential file or not
- [x] Teseted by running terrform when `service_account_exists` is `true` and `false`