### PR TITLE
CSM-7309: GCP Single Project not working on M1

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.61.0"
+      version = "~> 4.53.1"
     }
   }
 


### PR DESCRIPTION
Google provider vesrion 3.61.0 is not compatible to some platforms. So changed the version to 4.53.1