### PR TITLE
CSM-8629: GCP terraform : source code is pointing to github instead of terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Login with ADC
 
 ```
 module "create-gcp-cred" {
-  source                    = "github.com/uptycslabs/terraform-google-iam-config"
+  source                    = "uptycslabs/iam-config/google"
 
   # Modify Project details reequired
   gcp_project_id            = "<GCP-project-id>"


### PR DESCRIPTION
Change source from github repository to terraform registry