### PR TITLE
CSM-13310: Allow local-exec skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ module "create-gcp-cred" {
 
   # Modify if required
   integration_name = "uptycs-int-20220101"
+
+  # Set this to skip execution of local commands like "gcloud"
+  # If set to 'true', credential JSON file must be created outside of TF. Uptycs needs the credentials JSON file.
+  # Please refer to the TF output for "gcloud" that can generate the credentials JSON file
+  skip_local_exec = false
 }
 
 output "service-account-email" {
@@ -85,6 +90,7 @@ output "command-to-generate-gcp-cred-config" {
 | host_aws_account_id       | Uptycs's AWS Account ID. Copy from Uptycs's GCP Integration Screen UI          | `string`       | Yes      |                         |
 | host_aws_instance_roles    | AWS role names of Uptycs - for identity binding                                | `list(string)` | Yes      |                         |
 | integration_name          | Unique phrase used to name the resources                                       | `string`       |          | `"uptycs-int-20220101"` |
+| skip_local_exec           | Flag to skip local command execution                                  | `bool`         | false                   |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ resource "google_service_account_iam_binding" "workload_identity_binding" {
 }
 
 resource "null_resource" "cred_config_json" {
+  count = var.skip_local_exec == true ? 0 : 1
   provisioner "local-exec" {
     command     = "gcloud iam workload-identity-pools create-cred-config projects/${data.google_project.my_host_project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.create_wip.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.add_provider.workload_identity_pool_provider_id} --service-account=${var.service_account_exists == false ? google_service_account.sa_for_cloudquery[0].email : data.google_service_account.myaccount[0].email} --output-file=credentials.json --aws"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,9 @@ variable "host_aws_instance_roles" {
   type        = list 
   description = "AWS role names of Uptycs - for identity binding"
 }
+
+variable "skip_local_exec" {
+  type = bool
+  default = false
+  description = "Set this to true to skip executing local commands like gcloud"
+}


### PR DESCRIPTION
Allow skipping local exec so module does't depend on executing local commands like `gcloud`

Tested the following cases
 - [x] Leave new var to default
 - [x] Set `skip_local_exec = true`  and make sure it doest run `gcloud`
 - [x] Set `skip_local_exec = false`  and make sure it runs `gcloud`